### PR TITLE
Update README's Async Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,16 +78,6 @@ You're all set - but there's a few more settings you may want to know about too!
 When an error or message occurs, the notification is immediately sent to Sentry. Raven can be configured to send asynchronously:
 
 ```ruby
-config.async = lambda { |event|
-  Thread.new { Raven.send_event(event) }
-}
-```
-
-Using a thread to send events will be adequate for truly parallel Ruby platforms such as JRuby, though the benefit on MRI/CRuby will be limited. If the async callback raises an exception, Raven will attempt to send synchronously.
-
-Note that the naive example implementation has a major drawback - it can create an infinite number of threads. We recommend creating a background job, using your background job processor, that will send Sentry notifications in the background.
-
-```ruby
 config.async = lambda { |event| SentryJob.perform_later(event) }
 
 class SentryJob < ActiveJob::Base


### PR DESCRIPTION
It's really not good to show a code example using Ruby threads and then immediately recommend to the majority of users (MRI/CRuby) that they should avoid using it. Many copy and paste and go about their day. I just removed that exact code snippet from a large app and switched it run in AR 🙃 Many people implementing an exception tracker, at least for the first time, could be very new to Ruby or programming, and not understand how much thread contention can degrade performance.

The better example was already there. That's all that is needed. I figured I'd toss this your way and see if you agree. Maybe in the future async could be handled internally by raven itself so the user doesn't have to concern themselves with the joys of mri threads 😅

Thanks for all the work put into this gem btw. I've never had any issues with raven over the many years of using it!